### PR TITLE
deps(frontend): Update deprecated middleware and baseline-browser-mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@types/node": "^24",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "baseline-browser-mapping": "^2.9.14",
         "eslint": "^9",
         "eslint-config-next": "16.0.0",
         "tailwindcss": "^4",
@@ -3489,9 +3490,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.20.tgz",
-      "integrity": "sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
+      "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -7577,6 +7578,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
       "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.1",
         "@swc/helpers": "0.5.15",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "baseline-browser-mapping": "^2.9.14",
     "eslint": "^9",
     "eslint-config-next": "16.0.0",
     "tailwindcss": "^4",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export default function proxy(request: NextRequest) {
   // Solo manejar redirecciones de autenticación y headers
   // La protección de rutas admin se maneja a nivel de componente
   


### PR DESCRIPTION
Added de baseline-browser-mapping dependency to latest version and modified the deprecated `middleware.ts` to `proxy.ts`

Closes #69 